### PR TITLE
Allow users to pass edgeConfigExpirationSeconds + github actions to publish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,14 @@
+---
+name: 'Bug report'
+title: '[Bug]: '
+labels: bug
+---
+
+## Description
+[//]: # (Briefly describe the bug)
+
+## Impact
+[//]: # (Add detail on the impact of this issue, both the who and the how)
+
+## Artifacts
+[//]: # (Add screenshots / loom video, etc)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+---
+labels: mergeable
+---
+[//]: #  (Link to the issue corresponding to this chunk of work)
+Fixes: #__issue__
+
+## Motivation and Context
+[//]: #  (Why is this change required? What problem does it solve?)
+
+## Description
+[//]: # (Describe your changes in detail)
+
+## How has this been tested?
+[//]: # (Please describe in detail how you tested your changes)
+
+
+[//]: # (OPTIONAL)
+[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)

--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -1,0 +1,48 @@
+name: Test and lint SDK
+on:
+  pull_request:
+    paths:
+      - '**/*'
+
+jobs:
+  lint-test-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '18.x'
+      - uses: actions/cache@v2
+        with:
+          path: './node_modules'
+          key: ${{ runner.os }}-root-node-modules-${{ hashFiles('./yarn.lock') }}
+      - name: 'Set up GCP SDK for downloading test data'
+        uses: 'google-github-actions/setup-gcloud@v0'
+      - name: Install SDK dependencies
+        run: yarn --frozen-lockfile
+        working-directory: ./
+      - name: Check code with eslint
+        run: npx eslint '**/*.{ts,tsx}'
+        working-directory: ./
+      - name: Run tests
+        run: yarn test
+        working-directory: ./
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '18.x'
+      - uses: actions/cache@v2
+        with:
+          path: './node_modules'
+          key: ${{ runner.os }}-root-node-modules-${{ hashFiles('./yarn.lock') }}
+      - name: Install SDK dependencies
+        run: yarn --frozen-lockfile
+        working-directory: ./
+      - name: Run typecheck
+        run: yarn typecheck
+        working-directory: ./

--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -2,23 +2,23 @@ name: Test and lint SDK
 on:
   pull_request:
     paths:
-      - '**/*'
+      - "**/*"
 
 jobs:
   lint-test-sdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
-      - uses: actions/cache@v2
+          node-version: "18.x"
+      - uses: actions/cache@v3
         with:
-          path: './node_modules'
+          path: ./node_modules
           key: ${{ runner.os }}-root-node-modules-${{ hashFiles('./yarn.lock') }}
-      - name: 'Set up GCP SDK for downloading test data'
-        uses: 'google-github-actions/setup-gcloud@v0'
+      - name: "Set up GCP SDK for downloading test data"
+        uses: "google-github-actions/setup-gcloud@v1"
       - name: Install SDK dependencies
         run: yarn --frozen-lockfile
         working-directory: ./
@@ -28,17 +28,18 @@ jobs:
       - name: Run tests
         run: yarn test
         working-directory: ./
+
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
-      - uses: actions/cache@v2
+          node-version: "18.x"
+      - uses: actions/cache@v3
         with:
-          path: './node_modules'
+          path: ./node_modules
           key: ${{ runner.os }}-root-node-modules-${{ hashFiles('./yarn.lock') }}
       - name: Install SDK dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish to NPM
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - run: yarn install
+      - run: yarn test
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,11 +36,13 @@ export interface IClientConfig {
    * edgeConfig - string given on creation of Vercel Edge Config Store.
    * edgeConfigStoreId - id of created Vercel Edge Config Store.
    * vercelApiToken - Vercel API token with write access. Needed to write configs to Vercel Edge Config Store.
+   * edgeConfigExpirationSeconds - Time during which config, stored in vercel, is valid. Defaults to 30 seconds
    */
   vercelParams: {
     edgeConfig: string;
     edgeConfigStoreId: string;
     vercelApiToken: string;
+    edgeConfigExpirationSeconds?: number;
   };
 
   /**
@@ -164,6 +166,7 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
         config.vercelParams.edgeConfig,
         config.vercelParams.edgeConfigStoreId,
         config.vercelParams.vercelApiToken,
+        config.vercelParams.edgeConfigExpirationSeconds,
       ),
     );
 


### PR DESCRIPTION
This PR contains:
- several github workflows (like PR description struct, lint and publish workflows)
- new param for init function, to provide edgeConfigExpirationSeconds - ttl for config store. Default to 30 (per @aarsilv  suggestion in previous pr)

Before merging this pr, we need to add NPM_TOKEN go GH secrets in this repo