### PR TITLE
Pavel/add async

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install @eppo/vercel-edge-sdk
 
 ## Quick start
 
-Correct usage requires this SDK to be used in [Vercel Edge Middleware](https://vercel.com/docs/functions/edge-middleware) and in [Vercel Function](https://vercel.com/docs/functions/quickstart) for hydration and keeping stored config up-to-date.
+This SDK is inteded to be used in [Vercel Edge Middleware](https://vercel.com/docs/functions/edge-middleware) and in [Vercel Function](https://vercel.com/docs/functions/quickstart) for hydration and keeping stored config up-to-date.
 
 [Vercel Edge Config Store ](https://vercel.com/docs/storage/edge-config/using-edge-config) is required for storing Eppo configs.
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         },
     });
 
-    console.log('PREFETCH')
-
     res.status(200).json({ message: 'Prefetch success' });
   } catch(e) {
     res.status(500).json({ message: 'Prefetch error'});
@@ -161,6 +159,24 @@ Your middleware, each time running, will start this cloud function (by doing an 
 The flow is next:
 - if config stored in Vercel Config Store is not outdated, middleware will give return up-to-date assignment;
 - if config stored in Vercel Config Store is outdated, middleware will still give an assignment requested, just outdated, and send a request to start Vercel Function to prefetch up-to-date config; Next run of the middleware will give an updated result;
+
+
+### Vercel Cron Job
+
+You can hydrate data using [Vercel Cron Job](https://vercel.com/guides/how-to-setup-cron-jobs-on-vercel).
+For this, in your middleware, do not provide a URL to Vercel Function.
+Create a Vercel Function and as in the example above, and create a cron job like:
+
+```ts
+{
+  "crons": [
+    {
+      "path": "/api/eppo-prefetch",
+      "schedule": "0 5 * * *"
+    }
+  ]
+}
+```
 
 ## Assignment functions
 

--- a/example.ts
+++ b/example.ts
@@ -1,6 +1,6 @@
 import { IAssignmentLogger } from '@eppo/js-client-sdk-common';
 
-import { init } from './src/index';
+import { init, prefetchConfig } from './src/index';
 
 const assignmentLogger: IAssignmentLogger = {
   logAssignment(assignment) {
@@ -9,13 +9,24 @@ const assignmentLogger: IAssignmentLogger = {
 };
 
 async function main() {
+  await prefetchConfig({
+    apiKey: '...',
+    assignmentLogger,
+    vercelParams: {
+      edgeConfig: 'https://edge-config.vercel.com/...',
+      edgeConfigStoreId: '...',
+      vercelApiToken: '..',
+    },
+  });
+
   const eppoClient = await init({
-    apiKey: '<your-eppo-sdk-key>',
+    apiKey: '...',
     assignmentLogger,
     vercelParams: {
       edgeConfig: 'https://edge-config.vercel.com/...',
       edgeConfigStoreId: '...',
       vercelApiToken: '...',
+      vercelFunctionUrl: 'http://localhost:3001/api/eppo-prefetch',
     },
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/vercel-edge-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Eppo SDK for use in Vercel Edge Middleware",
   "main": "dist/index.js",
   "files": [

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -275,6 +275,7 @@ describe('EppoJSClient E2E test', () => {
       'test variation assignment splits',
       async ({ flag, variationType, defaultValue, subjects }: IAssignmentTestCase) => {
         const client = getInstance();
+        await client.fetchFlagConfigurations();
 
         const typeAssignmentFunctions = {
           [VariationType.BOOLEAN]: client.getBoolAssignment.bind(client),

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,10 @@ async function initClient(config: IClientConfig) {
     EppoJSClient.instance.setConfigurationRequestParameters(requestConfiguration);
 
     if (config.vercelParams.vercelFunctionUrl) {
-      fetch(config.vercelParams.vercelFunctionUrl);
+      const isConfigExpired = await configurationStore.isExpired();
+      if (isConfigExpired) {
+        fetch(config.vercelParams.vercelFunctionUrl);
+      }
     }
   } catch (error) {
     console.warn(

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,10 @@ async function initClient(config: IClientConfig) {
 
     EppoJSClient.instance.setLogger(config.assignmentLogger);
     EppoJSClient.instance.setConfigurationRequestParameters(requestConfiguration);
+
+    if (config.vercelParams.vercelFunctionUrl) {
+      fetch(config.vercelParams.vercelFunctionUrl);
+    }
   } catch (error) {
     console.warn(
       'Eppo SDK encountered an error initializing, assignment calls will return the default value and not be logged',


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Customer requested our sdk not to fetch data from Eppo in the Vercel middleware.

## Description
[//]: # (Describe your changes in detail)

To achieve this, we decided to allow users utilise [Vercel Functions](https://vercel.com/docs/functions/quickstart)
The idea is to use `init` in the middleware, which will not be fetching data from Eppo, but only from Vercel Config Store.

For this, new function was introduced, `prefetchConfig`, which users need to run in a Vercel Function.

Example: 

```ts
export const runtime = 'nodejs';

import { IAssignmentLogger, prefetchConfig } from '@eppo/vercel-edge-sdk';
import { NextApiRequest, NextApiResponse } from 'next';

const assignmentLogger: IAssignmentLogger = {
  logAssignment(assignment) {
    console.log('assignement', assignment)
  },
};

export default async function handler(req: NextApiRequest, res: NextApiResponse) {

  try {
    if (!process.env.EDGE_CONFIG) {
      throw new Error('Define EDGE_CONFIG env variable');
    }

    if (!process.env.EDGE_CONFIG_STORE_ID) {
      throw new Error('Define EDGE_CONFIG_STORE_ID env variable')
    }

    if (!process.env.EDGE_CONFIG_TOKEN) {
      throw new Error('Define EDGE_CONFIG_TOKEN env variable')
    }

    if (!process.env.INTERNAL_FEATURE_FLAG_API_KEY) {
      throw new Error('Define INTERNAL_FEATURE_FLAG_API_KEY env variable')
    }

    prefetchConfig({
      apiKey: process.env.INTERNAL_FEATURE_FLAG_API_KEY,
        assignmentLogger,
        vercelParams: {
          edgeConfig:
            'https://edge-config.vercel.com/ecfg_vsakv8iluwvqic8lwxoxh339bqlb?token=9fc67c50-bb1f-4803-aba3-afe83628af6d',
          edgeConfigStoreId: 'ecfg_vsakv8iluwvqic8lwxoxh339bqlb',
          vercelApiToken: '1MLofg72Lp6ZhvPkseUglxt4',
        },
    });

    console.log('PREFETCH')

    res.status(200).json({ message: 'Prefetch success' });
  } catch(e) {
    res.status(500).json({ message: 'Prefetch error'});
  }
}
```

This could be saved to file, e.g `pages/api/eppo-prefetch.ts`, which will create a Vercel Function with url `https://{domain}/api/eppo-prefetch`.
This url must be passed in the middleware, like

```ts
 const eppoClient = await init({
      apiKey: process.env.INTERNAL_FEATURE_FLAG_API_KEY,
      assignmentLogger,
      vercelParams: {
        edgeConfig: '',
        edgeConfigStoreId: '',
        vercelApiToken: ',
        vercelFunctionUrl: `https://{domain}/api/eppo-prefetch`,
      },
    });
```

and middleware will send a non-blocking fetch request to this function, which itself will hydrate Vercel Edge Config.

The only caveat is that on the very-very first request to Vercel app, Vercel Edge Config will not be hydrated.
Manual run of Vercel Function will help.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
