### PR TITLE
Adjust GH workflow for npm publish to use OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,30 @@
 name: Publish to NPM
+
 on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
-      - run: yarn install
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: yarn install --frozen-lockfile
+        env:
+          HUSKY: 0
+
       - run: yarn test
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
+      - run: yarn build
+
+      - run: npm publish --access public

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,10 @@ prepare: test-data
 	 rm -rf dist/
 	 yarn tsc
 	 yarn webpack
+
+## build
+.PHONY: build
+build:
+	rm -rf dist/
+	yarn tsc
+	yarn webpack

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "Eppo SDK for use in Vercel Edge Middleware",
   "main": "dist/index.js",
   "files": [
-    "/dist"
+    "dist"
   ],
   "typings": "dist/index.d.ts",
   "scripts": {
     "lint": "eslint '**/*.{ts,tsx}' --cache",
     "lint:fix": "eslint --fix '**/*.{ts,tsx}' --cache",
     "lint:fix-pre-commit": "eslint -c .eslintrc.pre-commit.js --fix '**/*.{ts,tsx}' --no-eslintrc --cache",
+    "build": "make build",
     "prepare": "make prepare",
     "pre-commit": "lint-staged && tsc && yarn docs",
     "typecheck": "tsc",


### PR DESCRIPTION
### Summary

Fix and modernize the npm publish process for `@eppo/vercel-edge-sdk` by migrating to npm OIDC publishing and making the build and publish steps deterministic and CI-safe.

---

### What changed

#### 1. GitHub Actions: npm publish via OIDC
- Replaced token-based publishing with **npm OIDC Trusted Publishers**
- Removed dependency on `NPM_TOKEN`
- Switched to native `npm publish`
- Added required `id-token: write` permissions
- Ensured build runs explicitly before publish
- Disabled Husky during CI install

#### 2. Makefile: separate build from dev setup
- Introduced a dedicated `build` target that:
  - Cleans `dist/`
  - Runs `tsc`
  - Runs `webpack`
- Kept `prepare` for local/dev workflows only (husky, test data, etc.)
- Prevented CI from running unnecessary or fragile steps (git hooks, repo cloning)

#### 3. package.json fixes
- Added explicit `build` script for CI usage
- Fixed `files` field to correctly include published artifacts:
  - `"/dist"` → `"dist"`
- Publishing now reliably includes compiled JS and type definitions

---

### Why this is needed

- Token-based npm publishing is being replaced by OIDC (more secure, no secrets)
- CI previously relied on implicit/local-only behavior (`prepare`)
- Without an explicit build step, CI could publish broken or empty packages
- Leading slash in `files` could exclude `dist` from the published package

---

### Result

- Secure, tokenless npm publishing via OIDC
- Deterministic CI builds
- Correct package contents on npm
- Clear separation between local dev setup and CI build logic

---

### How to verify

1. Create a GitHub release
2. Observe GitHub Actions:
   - build runs
   - `npm publish` succeeds without tokens
3. Verify npm package contains `dist/index.js` and `dist/index.d.ts`
